### PR TITLE
Feature: Camera shake

### DIFF
--- a/projectsinia/Assets/Assets/CinemachineShake.cs
+++ b/projectsinia/Assets/Assets/CinemachineShake.cs
@@ -1,0 +1,44 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Cinemachine;
+
+public class CinemachineShake : MonoBehaviour
+{
+    public static CinemachineShake Instance { get; private set; }
+
+    private CinemachineVirtualCamera vCamShake;
+    private float shakeTimer;
+    private float startingIntensity;
+    private float shakeTimerTotal;
+
+    void Awake()
+    {
+        Instance = this;
+        vCamShake = GetComponent<CinemachineVirtualCamera>();
+    }
+    public void ShakeCamera(float intensity, float time)
+    {
+        CinemachineBasicMultiChannelPerlin perlinNoise = vCamShake.GetCinemachineComponent<CinemachineBasicMultiChannelPerlin>();
+
+        perlinNoise.m_AmplitudeGain = intensity;
+
+        startingIntensity = intensity;
+        shakeTimerTotal = time;
+        shakeTimer = time;
+
+    }
+
+    void Update()
+    {
+        if(shakeTimer > 0f)
+        {
+            shakeTimer -= Time.deltaTime;
+
+            CinemachineBasicMultiChannelPerlin perlinNoise = vCamShake.GetCinemachineComponent<CinemachineBasicMultiChannelPerlin>();
+            perlinNoise.m_AmplitudeGain = Mathf.Lerp(startingIntensity, 0f, 1 - (shakeTimer / shakeTimerTotal));
+        }
+    }
+
+
+}

--- a/projectsinia/Assets/Assets/CinemachineShake.cs.meta
+++ b/projectsinia/Assets/Assets/CinemachineShake.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3adbe7780873eb5428d849e8bcf6704d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/projectsinia/Assets/Grid.cs
+++ b/projectsinia/Assets/Grid.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Grid : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/projectsinia/Assets/Grid.cs.meta
+++ b/projectsinia/Assets/Grid.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dacb6a428278cc742a995defa78c9b9d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/projectsinia/Assets/Screenshake.cs
+++ b/projectsinia/Assets/Screenshake.cs
@@ -1,0 +1,44 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Cinemachine;
+
+public class Screenshake : MonoBehaviour
+{
+    public CinemachineTransposer vcam;
+    private List<float> xShake = new List<float>();
+    private List<float> yShake = new List<float>();
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        vcam = GetComponent<CinemachineVirtualCamera>().GetCinemachineComponent<CinemachineTransposer>();
+    }
+
+    // Update is called once per frame
+    void LateUpdate()
+    {
+        if (Input.GetKeyDown(KeyCode.Mouse1))
+        {
+            GenerateShakePattern();
+        }
+    }
+
+    void GenerateShakePattern()
+    {
+        xShake.Add(Random.Range(-0.5f, 0.5f));
+        yShake.Add(Random.Range(-0.5f, 0.5f));
+        xShake.Add(Random.Range(0.5f, 1.5f));
+        yShake.Add(Random.Range(0.5f, 1.5f));
+
+        for (int i = 0; i < 2; i++)
+        {
+            //vcam.m_TrackedObjectOffset.y = yShake[Random.Range(0, yShake.Count - 1)];
+            //vcam.m_TrackedObjectOffset.x = xShake[Random.Range(0, yShake.Count - 1)];
+
+
+            //vcam.m_TrackedObjectOffset.y = 0;
+            //vcam.m_TrackedObjectOffset.x = 0;
+        }
+    }
+}

--- a/projectsinia/Assets/Screenshake.cs.meta
+++ b/projectsinia/Assets/Screenshake.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d220fb1faa360744f9d28082adb8211c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/projectsinia/Assets/Scripts/PlayerMovement.cs
+++ b/projectsinia/Assets/Scripts/PlayerMovement.cs
@@ -209,6 +209,7 @@ public class PlayerMovement : MonoBehaviour
 		#region DASH CHECKS
 		if (CanDash() && LastPressedDashTime > 0)
 		{
+			CinemachineShake.Instance.ShakeCamera(5f, 0.5f);
 			//Freeze game for split second. Adds juiciness and a bit of forgiveness over directional input
 			Sleep(Data.dashSleepTime);
 
@@ -461,6 +462,7 @@ public class PlayerMovement : MonoBehaviour
 	{
 		//Overall this method of dashing aims to mimic Celeste, if you're looking for
 		// a more physics-based approach try a method similar to that used in the jump
+
 
 		LastOnGroundTime = 0;
 		LastPressedDashTime = 0;


### PR DESCRIPTION
Adding camera shake feature, has been tested for errors. To use, attach the cinemachine shake script to your virtual camera and enable multi channel basic perlin noise. the camera shake is called as a static function.